### PR TITLE
CI: add CI to logs project

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,0 +1,76 @@
+name: Python Testing
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test_log_repo:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest,
+                   macos-latest]
+        python-version: [3.7, 3.8, 3.9]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      # install this (logs) project
+      - name: Install darshan_logs package
+        run: |
+          python -m pip install .
+      - name: obtain pydarshan pydarshan-devel branch
+        run: |
+          mkdir scratch
+          cd scratch
+          git clone https://github.com/darshan-hpc/darshan.git
+          cd darshan
+          git checkout pydarshan-devel
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip 
+          python -m pip install --upgrade pytest
+          # matplotlib is pinned because of
+          # gh-479
+          python -m pip install matplotlib==3.4.3
+      - if: ${{matrix.platform == 'macos-latest'}}
+        name: Install MacOS deps
+        run: |
+          brew install automake
+      - name: Install darshan-util
+        run: |
+          cd scratch/darshan
+          mkdir darshan_install
+          export DARSHAN_INSTALL_PATH=$PWD/darshan_install
+          git submodule update --init
+          ./prepare.sh
+          cd darshan-util
+          ./configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-pydarshan --enable-apxc-mod --enable-apmpi-mod
+          make
+          make install
+      - name: Install pydarshan
+        run: |
+          cd scratch/darshan/darshan-util/pydarshan
+          # TODO: use pip per gh-476
+          python setup.py install
+      # shim for importlib.resources on Python < 3.9
+      - if: ${{matrix.python-version < 3.9}}
+        name: Install importlib_resources
+        run: |
+          python -m pip install -U importlib_resources
+      # this should detect PRs that attempt to add log
+      # files that cannot be read by the main repo
+      - name: Run pytest to check for bad logs
+        run: |
+          export LD_LIBRARY_PATH=$PWD/scratch/darshan/darshan_install/lib
+          # the test suite is sensitive to
+          # relative dir for test file paths
+          cd scratch/darshan/darshan-util/pydarshan
+          pytest


### PR DESCRIPTION
* add a basic CI configuration that should cause PRs
that add log files that cannot be read by the main repo
project to fail (because it will run the main repo test suite
on all log files)